### PR TITLE
Updated Xenko version to "3.1.0.1-beta01-0396"

### DIFF
--- a/Xenko.CodeOnlySample.NetCore/Xenko.CodeOnlySample.NetCore.csproj
+++ b/Xenko.CodeOnlySample.NetCore/Xenko.CodeOnlySample.NetCore.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Xenko.CodeOnlySample\Xenko.CodeOnlySample.csproj" />
     <!-- Needed for custom runtime.json -->
-    <PackageReference Include="Xenko" Version="3.1.0.1-beta01-0349" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Xenko" Version="3.1.0.1-beta01-0396" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 
 </Project>

--- a/Xenko.CodeOnlySample/Xenko.CodeOnlySample.csproj
+++ b/Xenko.CodeOnlySample/Xenko.CodeOnlySample.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xenko.Engine" Version="3.1.0.1-beta01-0349" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Xenko.Core" Version="3.1.0.1-beta01-0349" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Xenko.Engine" Version="3.1.0.1-beta01-0396" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Xenko.Core" Version="3.1.0.1-beta01-0396" PrivateAssets="contentfiles;analyzers" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR will allow Xenko.CodeOnlySample to be build from console using "dotnet build".